### PR TITLE
Added SATA drive temperature monitoring, requires hddtemp

### DIFF
--- a/src/argononed.py
+++ b/src/argononed.py
@@ -178,6 +178,9 @@ def temp_check():
 	prevspeed=0
 	while True:
 		val = argonsysinfo_gettemp()
+		hddval = argonsysinfo_gethddtemp()
+		if hddval > val:
+			val = hddval
 		newspeed = get_fanspeed(val, fanconfig)
 		if newspeed < prevspeed:
 			# Pause 30s if reduce to prevent fluctuations

--- a/src/argonsysinfo.py
+++ b/src/argonsysinfo.py
@@ -7,6 +7,7 @@
 import os
 import time
 import socket
+import subprocess
 
 def argonsysinfo_listcpuusage(sleepsec = 1):
 	outputlist = []
@@ -152,6 +153,20 @@ def argonsysinfo_getip():
 		st.close()
 	return ipaddr
 
+def argonsysinfo_gethddtemp():
+	hddtemp = 0
+	try:
+		for disk in os.listdir("/dev/disk/by-id"):
+			if disk.startswith("ata"):
+				storedhddtemp = hddtemp
+				f = "sata:" + os.path.join("/dev/disk/by-id", disk)
+				process = subprocess.Popen(["/usr/sbin/hddtemp", "-n", f], shell=False, stdout=subprocess.PIPE)
+				hddtemp = int(process.communicate()[0])
+				if hddtemp > storedhddtemp:
+					storedhddtemp = hddtemp
+		return float(storedhddtemp)
+	except:
+		return 0
 
 def argonsysinfo_getrootdev():
 	tmp = os.popen('mount').read()

--- a/src/argonsysinfo.py
+++ b/src/argonsysinfo.py
@@ -155,10 +155,10 @@ def argonsysinfo_getip():
 
 def argonsysinfo_gethddtemp():
 	hddtemp = 0
+	storedhddtemp = 0
 	try:
 		for disk in os.listdir("/dev/disk/by-id"):
 			if disk.startswith("ata"):
-				storedhddtemp = hddtemp
 				f = "sata:" + os.path.join("/dev/disk/by-id", disk)
 				process = subprocess.Popen(["/usr/sbin/hddtemp", "-n", f], shell=False, stdout=subprocess.PIPE)
 				hddtemp = int(process.communicate()[0])

--- a/tutorials/install-dependencies.sh
+++ b/tutorials/install-dependencies.sh
@@ -10,7 +10,7 @@ argon_check_pkg() {
     fi
 }
 
-pkglist=(raspi-gpio python-rpi.gpio python3-rpi.gpio python-smbus python3-smbus i2c-tools)
+pkglist=(raspi-gpio python-rpi.gpio python3-rpi.gpio python-smbus python3-smbus i2c-tools hddtemp)
 for curpkg in ${pkglist[@]}; do
 	sudo apt-get install -y $curpkg
 	RESULT=$(argon_check_pkg "$curpkg")


### PR DESCRIPTION
This PR adds the ability to monitor the temperature of SATA drives connected to the Argon Eon and trigger the fan accordingly.

It requires `hddtemp`; this has been added to `tutorials/install-dependencies.sh` but has *not* been added to the official install script, as that's not part of this repository.

The code adds a new function, `argonsysinfo_gethddtemp()`: this goes through all disks found in `/dev/disk/by-id` which begin with `ata`, indicating an ATA or SATA type, and queries them one-by-one for the current temperature using `hddtemp`. Each time, the disk's temperature is compared to the highest previously-seen temperature; if the latest disk is hotter, that becomes the new highest. At the end, the highest-seen temperature is returned as a float for compatibility with the `argononed.py` script.

To minimise complexity and maintain compatibility with the existing fan configuration format, the new monitoring feature is integrated into `argononed.py` as simply as possible: the `argonsysinfo_gethddtemp()` function is queried for the hottest-running hard drive; if the drive is hotter than the CPU, the drive's temperature replaces the CPU temperature for the purpose of fan control (but not for the CPU temperature screen on the OLED.)

Thus the fan is now triggered by either the CPU temperature _or_ the hard drive temperature, _whichever is greater_. As a result, IO-intensive operations which increase hard drive temperature without putting strain on the CPU will still activate the fan - preventing the drives from overheating. Hopefully.

I'd recommend setting the activation temperature to a few degrees below peak operating temperature for the drives. I've been using:

```
#
# Argon Fan Configuration
#
# Min Temp=Fan Speed
40=50
60=80
70=100
```

If this PR is merged and it becomes a standard feature, please ensure you add `hddtemp` to the install script.

Thanks for reading!